### PR TITLE
Fixing -t option #1

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,11 +17,11 @@ program
   .name("evno")
   .version("1.0.0")
   .description("A CLI for using Linked Data Notification in Solid Pods")
-  .requiredOption("-n, --name <username>", "Username")
-  .requiredOption("-e, --email <email>", "Email")
-  .requiredOption("-p, --password <password>", "Password")
+  .option("-n, --name <username>", "Username")
+  .option("-e, --email <email>", "Email")
+  .option("-p, --password <password>", "Password")
   .option("-i, --idp <idp>", "Identity provider", "http://localhost:3001/")
-  .option("-t, --tokenLocation", "Client token storage location", "./")
+  .option("-t, --tokenLocation <tokenLocation>", "Client token storage location", "./")
 
 program.command('receive')
   .description("Watch an inbox for new notifications")
@@ -33,12 +33,12 @@ program.command('receive')
   .option("-o, --out <value>", "Output directory (the content of the resource)")
   // @ts-ignore
   .action(async (inboxUrl, options) => {
-    const { name, email, password, idp, clientCredentialsTokenStorageLocation } = program.opts()
+    const { name, email, password, idp, tokenLocation} = program.opts()
     const receiver = await Receiver.build({
-      name, email, password, idp, clientCredentialsTokenStorageLocation, cache: !options.nocache, cachePath: options.cachePath
+      name, email, password, idp, tokenLocation, cache: !options.nocache, cachePath: options.cachePath
     });
 
-    (!options.stdout) && console.log('Logged in as \'%s\' with id %s', name, receiver.webId)
+    (!options.stdout) && console.log('Logged with id %s', receiver.webId)
 
     receiver.start(inboxUrl, options.strategy)
     receiver.on('notification', async (n: EventNotification) => {
@@ -51,9 +51,9 @@ program.command('init')
   .argument("<baseUrl>", 'Base URL of the Solid pod')
   .argument("[inboxPath]", 'Path to inbox')
   .action(async (baseUrl, inboxPath, options) => {
-    const { name, email, password, idp, clientCredentialsTokenStorageLocation } = program.opts()
+    const { name, email, password, idp, tokenLocation} = program.opts()
     const receiver = await Receiver.build({
-      name, email, password, idp, clientCredentialsTokenStorageLocation
+      name, email, password, idp, tokenLocation
     });
 
     (!options.stdout) && console.log('Logged in as \'%s\' with id %s', name, receiver.webId)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -28,7 +28,7 @@ export interface IAuthOptions {
     email: string,
     password: string,
     idp: string,
-    clientCredentialsTokenStorageLocation?: string
+    tokenLocation?: string
 }
 
 export interface ISenderResult { success: boolean, location: string | null }

--- a/src/receiver.ts
+++ b/src/receiver.ts
@@ -55,12 +55,26 @@ export default class Receiver extends EventEmitter {
         email: string,
         password: string,
         idp: string,
-        clientCredentialsTokenStorageLocation?: string,
+        tokenLocation?: string,
         cache?: boolean,
         cachePath?: string,
     }): Promise<Receiver> {
-        let token = await generateCSSToken(options)
-        const session = await authenticateToken(token, options.idp)
+        let token 
+
+        if (options.tokenLocation) {
+            if (fs.existsSync(options.tokenLocation)) {
+                token = JSON.parse(fs.readFileSync(options.tokenLocation,'utf8'));
+            }
+            else {
+                token = await generateCSSToken(options)
+                fs.writeFileSync(options.tokenLocation,JSON.stringify(token)) 
+            }
+        }
+        else {
+            token = await generateCSSToken(options)
+        }
+
+        const session = await authenticateToken(token, token.idp)
 
         return new Receiver(session, { cache: !!options.cache, cachePath: options.cachePath })
     }


### PR DESCRIPTION
There are now two ways to login:

1. Provide on the command line `-n ... -e .. -p .. -i ...` options
2. Provide on the command line `-n ... -e .. -p .. -i ... -t tokenFile` option in the first run and use only `-t tokenFile` in all next runs